### PR TITLE
Bump Python image to 3.9

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up
         run: |
           docker --version
-          docker-compose --version
+          docker compose --version
           echo "${GITHUB_REF}"
       - name: Start services
         run: |

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 INGEST=ghcr.io/alephdata/ingest-file
-COMPOSE=docker-compose
+COMPOSE=docker compose
 DOCKER=$(COMPOSE) run --rm ingest-file
 
 .PHONY: build
@@ -36,7 +36,7 @@ format-check:
 	black --check .
 
 test: services
-	$(DOCKER) pytest --cov=ingestors --cov-report html --cov-report term
+	PYTHONDEVMODE=1 PYTHONTRACEMALLOC=1 $(DOCKER) pytest --cov=ingestors --cov-report html --cov-report term
 
 restart: build
 	$(COMPOSE) up --force-recreate --no-deps --detach ingest-file

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.2"
-
 services:
   postgres:
     image: postgres:10.0
@@ -12,6 +10,9 @@ services:
     image: redis:alpine
     command: ["redis-server", "--save", "3600", "10"]
 
+  rabbitmq:
+    image: rabbitmq:3.9-management-alpine
+
   ingest-file:
     build:
       context: .
@@ -22,7 +23,7 @@ services:
       - /data:mode=777
     environment:
       FTM_STORE_URI: postgresql://ingest:ingest@postgres/ingest
-      LOG_FORMAT: TEXT  # TEXT or JSON
+      LOG_FORMAT: TEXT # TEXT or JSON
     volumes:
       - "./ingestors:/ingestors/ingestors"
       - "./tests:/ingestors/tests"
@@ -33,3 +34,4 @@ services:
     depends_on:
       - postgres
       - redis
+      - rabbitmq

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,15 +3,17 @@ normality==2.5.0
 pantomime==0.6.1
 followthemoney==3.5.9
 followthemoney-store[postgresql]==3.1.0
-servicelayer[google,amazon]==1.22.2
+servicelayer[google,amazon]==1.23.0
 languagecodes==1.1.1
 countrytagger==0.1.2
 pyicu==2.12
 google-cloud-vision==3.7.2
-tesserocr==2.6.2
-spacy==3.6.1
+tesserocr==2.7.1
+spacy==3.6.1 # pinned because spacy 3.8 requires numpy >2 which breaks fasttext (see https://groups.google.com/g/fasttext-library/c/4EOM0-S6xHU)
+numpy<2.0.0 # pinned because otherwise spacy requires an incompatible numpy
 fingerprints==1.1.1
 fasttext==0.9.2
+pika==1.3.2
 
 # Development
 pytest==8.2.0
@@ -38,4 +40,5 @@ cryptography==41.0.7
 requests[security]==2.31.0
 pymupdf==1.21.1
 
+prometheus-client==0.17.1
 sentry_sdk==2.0.1

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -10,10 +10,12 @@ class AudioIngestorTest(TestCase):
         self.assertEqual(entity.first("processingStatus"), self.manager.STATUS_SUCCESS)
         self.assertEqual(entity.first("title"), "Core Media Audio")
         self.assertEqual(entity.first("generator"), "com.apple.VoiceMemos (iOS 11.4)")
-        self.assertEqual(
-            entity.first("authoredAt"),
+        # with the change to Python 3.9 and the debian base image we are seeing a change
+        # in the amount of data we are parsing here
+        assert entity.get("authoredAt") == [
+            datetime.datetime(2018, 6, 20, 12, 9, 28).isoformat(),
             datetime.datetime(2018, 6, 20, 12, 9, 42).isoformat(),
-        )
+        ]
         self.assertEqual(entity.first("duration"), "2808")
         self.assertEqual(entity.first("samplingRate"), "44100")
         self.assertEqual(entity.schema.name, "Audio")


### PR DESCRIPTION
Mirroring [the OCCRP version bump](https://github.com/alephdata/ingest-file/pull/660).